### PR TITLE
Use com.facebook.presto.presto-spi

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -6,20 +6,20 @@
 
     <groupId>fluentd</groupId>
     <artifactId>presto-fluentd</artifactId>
-    <version>0.0.4</version>
+    <version>0.0.6</version>
 
     <dependencies>
 
         <dependency>
             <groupId>com.facebook.presto</groupId>
             <artifactId>presto-spi</artifactId>
-            <version>0.207</version>
+            <version>0.267</version>
         </dependency>
 
         <dependency>
             <groupId>io.airlift</groupId>
             <artifactId>log</artifactId>
-            <version>0.163</version>
+            <version>201</version>
         </dependency>
 
         <dependency>

--- a/src/main/java/fluentd/FluentdListener.java
+++ b/src/main/java/fluentd/FluentdListener.java
@@ -41,17 +41,14 @@ public class FluentdListener implements EventListener {
         if(queryCompletedEvent.getStatistics().getAnalysisTime().isPresent()) {
             event.put("analysisTime", queryCompletedEvent.getStatistics().getAnalysisTime().get().toMillis());
         }
-        if(queryCompletedEvent.getStatistics().getDistributedPlanningTime().isPresent()) {
-            event.put("distributedPlanningTime", queryCompletedEvent.getStatistics().getDistributedPlanningTime().get().toMillis());
-        }
         event.put("peakTotalNonRevocableMemoryBytes", queryCompletedEvent.getStatistics().getPeakTotalNonRevocableMemoryBytes());
         event.put("peakUserMemoryBytes", queryCompletedEvent.getStatistics().getPeakUserMemoryBytes());
         event.put("totalBytes", queryCompletedEvent.getStatistics().getTotalBytes());
         event.put("totalRows", queryCompletedEvent.getStatistics().getTotalRows());
         event.put("outputBytes", queryCompletedEvent.getStatistics().getOutputBytes());
         event.put("outputRows", queryCompletedEvent.getStatistics().getOutputRows());
-        event.put("writtenBytes", queryCompletedEvent.getStatistics().getWrittenBytes());
-        event.put("writtenRows", queryCompletedEvent.getStatistics().getWrittenRows());
+        event.put("writtenOutputBytes", queryCompletedEvent.getStatistics().getWrittenOutputBytes());
+        event.put("writtenOutputRows", queryCompletedEvent.getStatistics().getWrittenOutputRows());
         event.put("cumulativeMemory", queryCompletedEvent.getStatistics().getCumulativeMemory());
         event.put("completedSplits", queryCompletedEvent.getStatistics().getCompletedSplits());
 


### PR DESCRIPTION
Upstream は 0.0.5 から prestosql を使うようになってしまったので EMR では動かなくなってしまった。
よって 0.0.4  cfd022e71caec61391a96106d4ba8620b588138 からブランチを切って以下の対応を入れて EMR 5.36.1 で使われている presto 0.267 で使えるようにする。

- 依存ライブラリの更新
- 削除された API への対応 https://github.com/prestodb/presto/pull/12595
- rename された API への対応 https://github.com/prestodb/presto/pull/12769

master にはマージできないので v0.0.4 から切った reproio/prestodb ブランチでやっていこうと思います。
依存ライブラリの関係で trino に移行するときには trino-fluentd を作らないといけない気がしています。
